### PR TITLE
Fix/add nu card text formatting

### DIFF
--- a/src/views/cards/link-with-media-and-actions.blade.php
+++ b/src/views/cards/link-with-media-and-actions.blade.php
@@ -30,9 +30,9 @@
                 <h2 class="{{ $titleClasses() }}">
                     {{ $title }}
                 </h2>
-                <p class="{{ $messageClasses() }}">
+                <div class="{{ $messageClasses() }}">
                     {!! $body !!}
-                </p>
+                </div>
             @endif
         </div>
 

--- a/src/views/cards/link-with-media-and-actions.blade.php
+++ b/src/views/cards/link-with-media-and-actions.blade.php
@@ -31,7 +31,7 @@
                     {{ $title }}
                 </h2>
                 <p class="{{ $messageClasses() }}">
-                    {{ $body }}
+                    {!! $body !!}
                 </p>
             @endif
         </div>

--- a/src/views/cards/link-with-media.blade.php
+++ b/src/views/cards/link-with-media.blade.php
@@ -37,9 +37,9 @@
                 <h2 class="{{ $titleClasses() }}">
                     {{ $title }}
                 </h2>
-                <p class="{{ $messageClasses() }}">
+                <div class="{{ $messageClasses() }}">
                     {!! $body !!}
-                </p>
+                </div>
             @endif
         </div>
 

--- a/src/views/cards/link-with-media.blade.php
+++ b/src/views/cards/link-with-media.blade.php
@@ -38,7 +38,7 @@
                     {{ $title }}
                 </h2>
                 <p class="{{ $messageClasses() }}">
-                    {{ $body }}
+                    {!! $body !!}
                 </p>
             @endif
         </div>

--- a/src/views/cards/simple-link.blade.php
+++ b/src/views/cards/simple-link.blade.php
@@ -10,9 +10,9 @@
             <h2 class="{{ $titleClasses() }}">
                 {{ $title }}
             </h2>
-            <p class="{{ $bodyClasses() }}">
+            <div class="{{ $bodyClasses() }}">
                 {!! $body !!}
-            </p>
+            </div>
         @endif
     </div>
 

--- a/src/views/cards/simple-link.blade.php
+++ b/src/views/cards/simple-link.blade.php
@@ -11,7 +11,7 @@
                 {{ $title }}
             </h2>
             <p class="{{ $bodyClasses() }}">
-                {{ $body }}
+                {!! $body !!}
             </p>
         @endif
     </div>

--- a/src/views/cards/simple-with-actions.blade.php
+++ b/src/views/cards/simple-with-actions.blade.php
@@ -8,7 +8,7 @@
                 {{ $title }}
             </h2>
             <p class="{{ $bodyClasses }}">
-                {{ $body }}
+                {!! $body !!}
             </p>
         @endif
     </div>

--- a/src/views/cards/simple-with-actions.blade.php
+++ b/src/views/cards/simple-with-actions.blade.php
@@ -7,9 +7,9 @@
             <h2 class="{{ $titleClasses() }}">
                 {{ $title }}
             </h2>
-            <p class="{{ $bodyClasses }}">
+            <div class="{{ $bodyClasses }}">
                 {!! $body !!}
-            </p>
+            </div>
         @endif
     </div>
 


### PR DESCRIPTION
THE ISSUE ([INC9182917](https://service.northeastern.edu/nav_to.do?uri=incident.do?sys_id=b506942197ce5510aaf73ad3f153af4a)) - Update to NU Cards block in Admissions site theme

EM is looking for new functionality of having the ability to add text formatting to the body of cards on the admissions site. The current use case is the need to add two short paragraphs to the card body of a simple card style. This block is used widely across the site for a bunch of different content types. Currently we have no ability to add text formatting to card content which makes the block less flexible. WYSIWYG for this field would be great. Deadline is completely flexible.

THE FIX

I've made a change to the NuCards.php template in kernl_theme for the admissions site to allow block edtior WYSIWYG entering of html entities in the body field for all NUCard types (see https://github.com/ITS-Digital-Technology/kernl-theme/pull/208), but we also need to make a corresponding change in the blade files here, since kernl-theme is dependent on them to render the content correctly.

So, we need to display unescaped data in the body field for the relevant blade files:

src/views/cards/link-with-media-and-actions.blade.php
src/views/cards/link-with-media.blade.php
src/views/cards/simple-link.blade.php
src/views/cards/simple-with-actions.blade.php

I've tested this on local dev and it works.

