### PR TITLE
Update minimum PHP requirements to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10",
-        "illuminate/view": "^10"
+        "illuminate/support": "^10.0",
+        "illuminate/view": "^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17.0"

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/support": "^10.0",
-        "illuminate/view": "^10.0"
+        "php": "^7.2|^8.1",
+        "illuminate/support": "^7.0|^9.0",
+        "illuminate/view": "^7.0|^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17.0"

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/support": "^7.0|^8.0",
-        "illuminate/view": "^7.0|^8.0"
+        "php": "^8.1",
+        "illuminate/support": "^10",
+        "illuminate/view": "^10"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.16.10"
+        "friendsofphp/php-cs-fixer": "^3.17.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- `Illuminate/view` and `illuminate/support` packages to version 9*.

<sup>*</sup>Other packages, like [Acorn](https://github.com/roots/acorn/blob/main/composer.json#L46-L58) support Laravel packages up to 9.5